### PR TITLE
Replaced strict peer dependency react=17.0.0 with react>17 or >18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galactic-state",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "galactic-state",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.12.8",
@@ -30,7 +30,7 @@
         "typescript": "^4.1.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || 17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -39,8 +39,6 @@
       "integrity": "sha512-/6nQj11oaGhLmZiuRUfxsujiPDc9BBReemiXgIbxc+M5W+MIiFKYwvNDJvBfnGKNsJTKbUfEheKc9cwoPHAVQA==",
       "dev": true,
       "dependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -1602,7 +1600,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3556,8 +3553,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5788,7 +5784,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Baron Willeford",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.0 || 17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
Relates to #6.

Hint: I'm using/testing gallactic state with react: 18.2.0 (successful).
